### PR TITLE
Configure 'processes/threads' and fd limits in OS

### DIFF
--- a/src/s14e/Vagrantfile
+++ b/src/s14e/Vagrantfile
@@ -11,6 +11,9 @@ end
 
 data_hash = JSON.parse(data_file)
 
+max_user_processes = 16000
+max_file_descriptors = 64000
+
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
@@ -30,10 +33,20 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell",
         privileged: false,
         inline: <<-SHELL
-            sudo timedatectl set-timezone Europe/Madrid
             sudo mkdir -p /usr/local
             sudo tar -xzf /tmp/splunk-enterprise.tgz -C /usr/local/
             sudo chown -R vagrant:vagrant /usr/local/splunk
+    SHELL
+
+    config.vm.provision "default_setup", type: "shell" do |s|
+        s.path = "./scripts/default_setup.sh"
+        s.args = [max_file_descriptors, max_user_processes]
+    end
+
+    config.vm.provision "reboot", type: "shell", reboot: true, inline: <<-SHELL
+        echo "----------"
+        echo "| REBOOT |"
+        echo "----------"
     SHELL
 
     config.vm.provision "file",

--- a/src/s14e/scripts/default_setup.sh
+++ b/src/s14e/scripts/default_setup.sh
@@ -1,0 +1,16 @@
+echo "[INFO] Configuring timezone to Europe/Madrid"
+#---------------------------------------------------
+timedatectl set-timezone Europe/Madrid
+
+
+echo "[INFO] Configuring limits for vagrant user"
+#---------------------------------------------------
+echo "" >> /etc/security/limits.conf
+
+echo "#Parametros vagrant" >> /etc/security/limits.conf
+
+echo "vagrant soft nofile $1" >> /etc/security/limits.conf
+echo "vagrant hard nofile $1" >> /etc/security/limits.conf
+
+echo "vagrant soft nproc $2" >> /etc/security/limits.conf
+echo "vagrant hard nproc $2" >> /etc/security/limits.conf


### PR DESCRIPTION
Fix the following messages diplsayed in splunkd.log:
- WARN  main - The hard limit of 'processes/threads' is lower than the recommended value. The hard limit is: 3873. The recommended value is: 16000.
- WARN  main - The hard fd limit is lower than the recommended value. The hard limit is '4096' The recommended value is '64000'.